### PR TITLE
Timed metric exception with Histograms

### DIFF
--- a/src/main/graal/reflect.json
+++ b/src/main/graal/reflect.json
@@ -23,5 +23,15 @@
     "name": "io.micronaut.configuration.metrics.management.endpoint.MetricsEndpoint$Sample",
     "allDeclaredConstructors": true,
     "allPublicMethods": true
+  },
+  {
+    "name": "org.HdrHistogram.Histogram",
+    "allDeclaredConstructors": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "org.HdrHistogram.ConcurrentHistogram",
+    "allDeclaredConstructors": true,
+    "allPublicMethods": true
   }
 ]


### PR DESCRIPTION
Timed metric will throw exceptions when trying to instantiate Histogram and ConcurrentHistogram classes